### PR TITLE
Fix build for vision-camera 3.7.1

### DIFF
--- a/android/src/main/java/com/visioncameraocr/OCRFrameProcessorPlugin.kt
+++ b/android/src/main/java/com/visioncameraocr/OCRFrameProcessorPlugin.kt
@@ -141,7 +141,7 @@
 
          @SuppressLint("UnsafeOptInUsageError")
          val mediaImage: Image? = frame.image
-         val orientation = Orientation.fromUnionValue(frame.orientation)
+         val orientation = Orientation.fromUnionValue(frame.orientation.toString())
 
          if (mediaImage != null && orientation!= null) {
              val image = InputImage.fromMediaImage(mediaImage, orientation.toDegrees())


### PR DESCRIPTION
This seems to be enough to fix builds for `"react-native-vision-camera": "3.7.1"`