### PR TITLE
iOS - Fix incompatible block type and 'init' method unavailability in…

### DIFF
--- a/ios/VisionCameraOcr.m
+++ b/ios/VisionCameraOcr.m
@@ -11,10 +11,10 @@
 
 + (void)load
 {
-  [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"scanOCR"
-                                        withInitializer:^FrameProcessorPlugin* (NSDictionary* options) {
-    return [[OCRFrameProcessorPlugin alloc] init];
-  }];
+    [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"scanOCR"
+                                        withInitializer:^FrameProcessorPlugin* (VisionCameraProxyHolder* proxy, NSDictionary* options) {
+        return [[OCRFrameProcessorPlugin alloc] initWithProxy:proxy withOptions:options];
+    }];
 }
 
 @end


### PR DESCRIPTION
This PR resolves the following issues in the versions of `react-native-vision-camera` starting with `"react-native-vision-camera": "3.7.1"`:
- incompatible block type in FrameProcessorPluginRegistry
- 'init' method unavailability in FrameProcessorPlugin