### PR TITLE
fix(types): declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "VisionCamera Frame Processor Plugin to provide OCR support",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
[bob](https://github.com/callstack/react-native-builder-bob) was putting the definition file in `lib/typescript/src/index.d.ts`

![image](https://github.com/ismaelsousa/vision-camera-ocr/assets/107975184/c2e8d06f-61b1-4ffa-a265-f8bb56fe9cb4)

```sh
$ bob build
ℹ Building target commonjs
ℹ Cleaning up previous build at lib/commonjs
ℹ Compiling 1 files in src with babel
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
✔ Wrote files to lib/commonjs
ℹ Building target module
ℹ Cleaning up previous build at lib/module
ℹ Compiling 1 files in src with babel
✔ Wrote files to lib/module
ℹ Building target typescript
ℹ Cleaning up previous build at lib/typescript
ℹ Generating type definitions with tsc
✔ Wrote definition files to lib/typescript
```

- https://github.com/callstack/react-native-builder-bob/issues/140