### PR TITLE
Ios use_frameworks! :linkage => :static compatibility

### DIFF
--- a/VisionCameraOcr.podspec
+++ b/VisionCameraOcr.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "GoogleMLKit/TextRecognition", "3.1.0"
+  s.dependency "GoogleMLKit/TextRecognition"
+  s.dependency "VisionCamera"
 end

--- a/ios/VisionCameraOcr.m
+++ b/ios/VisionCameraOcr.m
@@ -2,7 +2,13 @@
 #import <VisionCamera/FrameProcessorPlugin.h>
 #import <VisionCamera/FrameProcessorPluginRegistry.h>
 
+// use_framework! import
+#if __has_include(<VisionCameraOcr/VisionCameraOcr-Swift.h>)
+#import "VisionCameraOcr/VisionCameraOcr-Swift.h"
+#endif
+#if __has_include("VisionCameraOcr-Swift.h")
 #import "VisionCameraOcr-Swift.h"
+#endif
 
 @interface OCRFrameProcessorPlugin (FrameProcessorPluginLoader)
 @end

--- a/ios/VisionCameraOcr.swift
+++ b/ios/VisionCameraOcr.swift
@@ -4,6 +4,10 @@ import MLKitVision
 import MLKitTextRecognition
 import CoreImage
 import UIKit
+// use_framework! import
+#if canImport(VisionCamera)
+import VisionCamera
+#endif
 
 @objc(OCRFrameProcessorPlugin)
 public class OCRFrameProcessorPlugin: FrameProcessorPlugin {


### PR DESCRIPTION
Since I am using Firebase in my project, I need to build my app with static frameworks.
After I run into some build issues, changing the dependencies and imports, this seem to work. 
Since I'm not too familiar with ios development... is there is a cleaner way to achieve this?


Thanks for your work so far!